### PR TITLE
Fix #8 修正 iso check

### DIFF
--- a/iso_chk_linux.sh
+++ b/iso_chk_linux.sh
@@ -187,8 +187,8 @@ echo "==================================" >> $outfil
 echo "cat /etc/xinetd.conf |grep -v "^#""  >> $outfil
 cat /etc/xinetd.conf |grep -v "^#"  >> $outfil
 echo "----------------------------------" >> $outfil
-echo "chkconfig --list |tail -18 "  >> $outfil
-chkconfig --list |tail -18   >> $outfil
+echo "systemctl list-unit-files"          >> $outfil
+systemctl list-unit-files                 >> $outfil
 echo "----------------------------------" >> $outfil
 echo "  " >> $outfil
 


### PR DESCRIPTION
前兩個錯誤可以忽略
chkconfig --list |tail -18 改為 systemctl list-unit-files
sam 改為 /etc/SuSE-release